### PR TITLE
Add a cronjob for feed updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Attributes
 * `node['tt-rss']['url']` - URL of the web site. Default `http://my-tinyrss.com/`
 * `node['tt-rss']['server_name']` - Name of the server, used in apache site configuration. Default `my-tinyrss.com`
 * `node['tt-rss']['install_dir']` - Installation directory. Default `/opt/tt-rss`
+* `node['tt-rss']['log_destination']` - Tiny Tiny RSS log destination configuration. Valid values are `sql` to log in the database (can be read using Preferences -> System), `syslog` to log to the system log, or blank string which uses PHP logging. Default `sql`
+* `node['tt-rss']['install_dir']` - Installation directory. Default `/opt/tt-rss`
+* `node['tt-rss']['update_feeds']['cron']` - If true, the cookbook installs a cron job to update feeds in /etc/cron.d/ttrss-update. Default `true`
+* `node['tt-rss']['install_dir']['cron_expression']` - The cron expression that determines how frequently to update feeds.  Default `17 */4 * * * (every 4 hours at 17min after the hour)`
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,6 @@
 default['tt-rss']['database']['user']     = 'tt-rss'
 default['tt-rss']['database']['password'] = 'tt-rss'
 default['tt-rss']['database']['name']     = 'tt-rss'
-default['tt-rss']['database']['host']     = 'localhost'
 
 default['tt-rss']['download-url'] = 'https://github.com/gothfox/Tiny-Tiny-RSS/archive/1.10.tar.gz'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,9 @@ default['tt-rss']['server_name'] = "my-tinyrss.com"
 default['tt-rss']['url']         = "http://my-tinyrss.com"
 default['tt-rss']['install_dir'] = "/opt/tt-rss"
 
+# sql for in-app (view with Preferences -> system,
+# syslog to log to the system logs,
+# empty string for php logging (which is usually to error.log)
 default['tt-rss']['log_destination'] = 'sql'
 
 default['tt-rss']['update_feeds']['cron'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,3 +15,6 @@ default['tt-rss']['url']         = "http://my-tinyrss.com"
 default['tt-rss']['install_dir'] = "/opt/tt-rss"
 
 default['tt-rss']['log_destination'] = 'sql'
+
+default['tt-rss']['update_feeds']['cron'] = true
+default['tt-rss']['update_feeds']['cron_expression'] = '17 */4 * * *'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -117,9 +117,9 @@ end
 file '/etc/cron.d/ttrss-update' do
   # The trailing \n (newline) is required for cron to parse the file correctly
   content "#{node['tt-rss']['update_feeds']['cron_expression']} www-data /usr/bin/php #{install_dir}/update.php --feeds 2>&1 | logger -t ttrss-update\n"
-  owner 'www-data'
-  group 'www-data'
-  mode "0755"
+  owner 'root'
+  group 'root'
+  mode "0644"
   action :create
   only_if { node['tt-rss']['update_feeds']['cron'] }
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -32,6 +32,9 @@ describe 'tt-rss' do
   end
   it 'creates the tt-rss config.php' do
     expect(chef_run).to create_file "#{chef_run.node['tt-rss']['install_dir']}/config.php"
-    #expect(chef_run).to create_file_with_content "#{chef_run.node['tt-rss']['install_dir']}/config.php" 'define'
+    #expect(chef_run).to create_file_with_content "#{chef_run.node['tt-rss']['install_dir']}/config.php", 'define'
+  end
+  it 'creates the update_feeds cronjob' do
+    expect(chef_run).to create_file_with_content '/etc/cron.d/ttrss-update', '/usr/bin/php'
   end
 end


### PR DESCRIPTION
Automates deployment of a simple cron job to update feeds periodically, with frequency determined by a cron-expression attribute.
